### PR TITLE
Rakefile references other rb files

### DIFF
--- a/lib/Rakefile
+++ b/lib/Rakefile
@@ -1,3 +1,6 @@
+# Reference other rake files to avoid adding the -f parameter when executing the rake command
+FileList['**/*.rb'].each { |rf| require_relative rf }
+
 MISE_EXEC_PREFIX = 'mise exec --'
 
 namespace :env do


### PR DESCRIPTION
Reference other rake files to avoid adding the -f parameter when executing the rake command